### PR TITLE
Fix webhook data after signup

### DIFF
--- a/src/components/SignupDialog.tsx
+++ b/src/components/SignupDialog.tsx
@@ -32,7 +32,7 @@ const SignupDialog = ({ isOpen, onClose }: SignupDialogProps) => {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const sendWebhook = async (userData: { name: string; email: string }) => {
+  const sendWebhook = async (userData: { id?: string; name: string; email: string }) => {
     try {
       console.log('Enviando webhook para n8n:', userData);
       
@@ -42,6 +42,7 @@ const SignupDialog = ({ isOpen, onClose }: SignupDialogProps) => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
+          id: userData.id,
           name: userData.name,
           email: userData.email,
           timestamp: new Date().toISOString(),
@@ -75,7 +76,11 @@ const SignupDialog = ({ isOpen, onClose }: SignupDialogProps) => {
 
     setIsSubmitting(true);
     
-    const { error } = await signUp(formData.email, formData.password);
+    const { data, error } = await signUp(
+      formData.email,
+      formData.password,
+      formData.name
+    );
     
     if (error) {
       console.error('Signup error:', error);
@@ -89,6 +94,7 @@ const SignupDialog = ({ isOpen, onClose }: SignupDialogProps) => {
     } else {
       // Enviar webhook com os dados do usuário
       await sendWebhook({
+        id: data?.user?.id,
         name: formData.name,
         email: formData.email
       });

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,7 +7,11 @@ interface AuthContextType {
   user: User | null;
   session: Session | null;
   signIn: (email: string, password: string) => Promise<{ error: any }>;
-  signUp: (email: string, password: string) => Promise<{ error: any }>;
+  signUp: (
+    email: string,
+    password: string,
+    name: string
+  ) => Promise<{ data: { user: User | null; session: Session | null } | null; error: any }>;
   signOut: () => Promise<void>;
   loading: boolean;
 }
@@ -57,17 +61,18 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     return { error };
   };
 
-  const signUp = async (email: string, password: string) => {
+  const signUp = async (email: string, password: string, name: string) => {
     const redirectUrl = `${window.location.origin}/`;
-    
-    const { error } = await supabase.auth.signUp({
+
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
+        data: { full_name: name },
         emailRedirectTo: redirectUrl
       }
     });
-    return { error };
+    return { data, error };
   };
 
   const signOut = async () => {


### PR DESCRIPTION
## Summary
- include `name` when signing up with Supabase
- return created user from `signUp`
- forward user `id` in signup webhook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852cd5cc1188323a7a8db44f5092ade